### PR TITLE
backend: Fix negative skip & limit

### DIFF
--- a/backend/src/data-access/database.ts
+++ b/backend/src/data-access/database.ts
@@ -68,8 +68,8 @@ export class LogsRepository extends Database {
     const logs = await collection
       .find(query)
       .sort({ orderingKey: -1 })
-      .skip(skip)
-      .limit(limit)
+      .skip(skip > 0 ? skip : 0)
+      .limit(limit > 0 ? limit : 0)
       .toArray();
 
     const count = await collection.countDocuments(query);


### PR DESCRIPTION
If skip or limit is negative, the mongodb backend falls over.  Limit them to non-negative values only.  This is mainly seen when the grid is set to show all entries.

I have additional changes available, but I didn't want to overwhelm you with PRs; let me know if you think you'd want them.  Alternatively, just pull the commits in directly; that's fine too.

https://github.com/edwin-abraham-thomas/LogLens/compare/main...mook-as:rdx-LogLens:fix/case-sensitive-fs — fix compilation on case-sensitive file systems. (I assume you're running Windows.)
https://github.com/edwin-abraham-thomas/LogLens/compare/main...mook-as:rdx-LogLens:fix/filter-window-styles — When I build the extension locally, the docker theme colors seem to be unavailable; I used the stock MUI colors instead.  If things work for you it's probably a local issue?